### PR TITLE
Fix rawAccelChanged parameters

### DIFF
--- a/gui/src/trackersettings.cpp
+++ b/gui/src/trackersettings.cpp
@@ -556,9 +556,9 @@ void TrackerSettings::setLiveDataMap(const QVariantMap &livelist,bool reset)
             ge = true;
         }
         if((i.key() == "accx" || i.key() == "accy" || i.key() == "accz") && !ae) {
-            emit(rawAccelChanged(_live["gyrox"].toFloat(),
-                                _live["gyroy"].toFloat(),
-                                _live["gyroz"].toFloat()));
+            emit(rawAccelChanged(_live["accx"].toFloat(),
+                                _live["accy"].toFloat(),
+                                _live["accz"].toFloat()));
             ae = true;
         }
         if((i.key() == "magx" || i.key() == "magy" || i.key() == "magz") && !me) {


### PR DESCRIPTION
## Summary
- use accelerometer fields when emitting `rawAccelChanged`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684564c3df6883318c8b14ec9114877b