### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RC HeadTracker
-If your an RC enthusiast like myself with a FPV headset at some point you thought wouldn't it be cool if I could turn my head and the camera would follow. That is the intention of this project. It is a continuation of the work started by Dennis Frie, Mark Mansur and others in an effort to make it a more simple project.
+If you're an RC enthusiast like myself with a FPV headset at some point you thought wouldn't it be cool if I could turn my head and the camera would follow. That is the intention of this project. It is a continuation of the work started by Dennis Frie, Mark Mansur and others in an effort to make it a more simple project.
 
 I would like to throw out thanks to Yuri for the BLE Para work. https://github.com/ysoldak/HeadTracker
 
 ## [Wiki](https://github.com/dlktdr/HeadTracker/wiki)
-* Please visit the  for the hardware required and how to build one.
+* Please visit the Wiki for the hardware required and how to build one.
 
 ## [Nano33BLE Build Link](https://github.com/dlktdr/HeadTracker/wiki/Nano33BLE-Build-Instructions)
 * How to for the new BLE33 board
@@ -13,7 +13,7 @@ I would like to throw out thanks to Yuri for the BLE Para work. https://github.c
 * How to for the BNO055 Sensor board + Arduino Nano
 
 ## [Download](https://github.com/dlktdr/HeadTracker/releases)
-* Download the latest version from here if your running Windows 7,8,10. 
+* Download the latest version from here if you're running Windows 7,8,10.
 * The GUI should compile on Linux and MacOS but I have not tested it (*Firmware upload will not work).
 
 ### To Do
@@ -35,6 +35,6 @@ I would like to throw out thanks to Yuri for the BLE Para work. https://github.c
 
 ### Compiling Code
 
-I used VS Code & Platform IO to write this. It should work equally well in Arduino's IDE if thats your choice. Please rename the Nano33BLE.cpp to Nano33BLE.ino. It will complain about the startup folder just allow it to move it. I've had an issue with the most recent JSON library so I downgraded to 6.17.2
+I used VS Code & Platform IO to write this. It should work equally well in Arduino's IDE if that’s your choice. Please rename the Nano33BLE.cpp to Nano33BLE.ino. It will complain about the startup folder just allow it to move it. I've had an issue with the most recent JSON library so I downgraded to 6.17.2
 
 There is also a patch that needs to be applied to the Arduino BLE library or PARA will not connect. Please see https://github.com/ysoldak/ArduinoBLE/compare/master...ysoldak:cccd_hack


### PR DESCRIPTION
## Summary
- fix various typos in README
- clarify Wiki link for build instructions

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684564d005688331ae1d2c440cfaf89a