### PR TITLE
Add unit test for TrackerSettings rawAccelChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ I would like to throw out thanks to Yuri for the BLE Para work. https://github.c
 I used VS Code & Platform IO to write this. It should work equally well in Arduino's IDE if that’s your choice. Please rename the Nano33BLE.cpp to Nano33BLE.ino. It will complain about the startup folder just allow it to move it. I've had an issue with the most recent JSON library so I downgraded to 6.17.2
 
 There is also a patch that needs to be applied to the Arduino BLE library or PARA will not connect. Please see https://github.com/ysoldak/ArduinoBLE/compare/master...ysoldak:cccd_hack
+
+## Running Tests
+The GUI tests use Qt's Test module. To build and run the tracker settings test:
+
+```bash
+cd gui/tests
+mkdir build && cd build
+cmake ..
+make
+./trackersettings_test
+```

--- a/gui/tests/CMakeLists.txt
+++ b/gui/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+project(trackersettings_test LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Core Test)
+
+add_executable(trackersettings_test
+    trackersettings_test.cpp
+    ../src/trackersettings.cpp
+)
+
+target_include_directories(trackersettings_test PRIVATE ../src)
+
+target_link_libraries(trackersettings_test Qt5::Core Qt5::Test)

--- a/gui/tests/trackersettings_test.cpp
+++ b/gui/tests/trackersettings_test.cpp
@@ -1,0 +1,48 @@
+#include <QtTest>
+#include "../src/trackersettings.h"
+
+// To run this test, create a build directory and use CMake:
+// $ mkdir build && cd build
+// $ cmake .. && make
+// $ ./trackersettings_test
+
+class TrackerSettingsTest : public QObject {
+    Q_OBJECT
+private slots:
+    void rawAccelSignal_data();
+    void rawAccelSignal();
+};
+
+void TrackerSettingsTest::rawAccelSignal_data()
+{
+    QTest::addColumn<float>("x");
+    QTest::addColumn<float>("y");
+    QTest::addColumn<float>("z");
+
+    QTest::newRow("basic") << 1.0f << 2.0f << 3.0f;
+}
+
+void TrackerSettingsTest::rawAccelSignal()
+{
+    QFETCH(float, x);
+    QFETCH(float, y);
+    QFETCH(float, z);
+
+    TrackerSettings settings;
+    QSignalSpy spy(&settings, SIGNAL(rawAccelChanged(float,float,float)));
+
+    QVariantMap map;
+    map["accx"] = x;
+    map["accy"] = y;
+    map["accz"] = z;
+    settings.setLiveDataMap(map);
+
+    QCOMPARE(spy.count(), 1);
+    const QList<QVariant> arguments = spy.takeFirst();
+    QCOMPARE(arguments.at(0).toFloat(), x);
+    QCOMPARE(arguments.at(1).toFloat(), y);
+    QCOMPARE(arguments.at(2).toFloat(), z);
+}
+
+QTEST_MAIN(TrackerSettingsTest)
+#include "trackersettings_test.moc"


### PR DESCRIPTION
## Summary
- add Qt unit test for TrackerSettings
- create basic CMake file for building the test
- document how to run tests

## Testing
- `cmake ..` *(fails: could not find Qt5)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6845657f918c83319ba96e15f337f228